### PR TITLE
alpha 0.1.1 (redo)

### DIFF
--- a/src-tauri/src/api/common.rs
+++ b/src-tauri/src/api/common.rs
@@ -4,7 +4,7 @@ use reqwest::cookie::Jar;
 
 pub const API_BASE_URL: &str = "https://api.vrchat.cloud/api/1";
 
-const USER_AGENT: &str = "WM (formerly VRC Worlds Manager)/0.0.1 discord:raifa";
+const USER_AGENT: &str = "VRC Worlds Manager/0.1.1 discord:raifa";
 
 pub fn get_reqwest_client(cookies: &Arc<Jar>) -> reqwest::Client {
     reqwest::ClientBuilder::new()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,7 @@
   "plugins": {
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVDNTJCMzNBMzVGQzk4MEYKUldRUG1QdzFPck5TWEE5UjZxUDc0ZDVwZThnM29RODlpNzl6bDhZbzA0YllQa3FUb1k5Qy93c28K",
-      "endpoints": ["https://releases.raifaworks.com/stable.json"]
+      "endpoints": ["https://releases.raifaworks.com/manifests/stable.json"]
     }
   }
 }


### PR DESCRIPTION
This pull request includes updates to the user agent string and the updater endpoint URL. 

Configuration updates:

* [`src-tauri/src/api/common.rs`](diffhunk://#diff-1e5899b22123b83c30485e82452652056be930bebc37d804a794b51e7cd04586L7-R7): Updated the `USER_AGENT` constant to reflect the new version "VRC Worlds Manager/0.1.1".
* [`src-tauri/tauri.conf.json`](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L42-R42): Changed the updater endpoint URL to "https://releases.raifaworks.com/manifests/stable.json".…figuration