### PR TITLE
alpha release 0.1.2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5548,7 +5548,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vrc-worlds-manager"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aes",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrc-worlds-manager"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src/components/about-section.tsx
+++ b/src/components/about-section.tsx
@@ -177,7 +177,7 @@ export function AboutSection() {
       {/* Bottom Bar - Changed from fixed to absolute positioning */}
       <div className="absolute bottom-0 inset-x-0 pl-4 pr-4 border-t items-center bg-background/80 backdrop-blur-sm flex justify-between items-center">
         <div className="text-sm text-muted-foreground">
-          VRC Worlds Manager v.0.1.0
+          VRC Worlds Manager v.0.1.2a
         </div>
 
         <div className="flex gap-4">


### PR DESCRIPTION
This pull request includes a version update and a minor UI change in the `vrc-worlds-manager` project.

Version update:

* [`src-tauri/Cargo.toml`](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39L3-R3): Updated the version of the package from `0.1.1` to `0.1.2`.

UI change:

* [`src/components/about-section.tsx`](diffhunk://#diff-90f3bd7cb1d572de533be47281e35060ecb19fdb6d4ac1888ecdc196e62ad16cL180-R180): Updated the version displayed in the About Section from `0.1.0` to `0.1.2a` and changed the positioning of the bottom bar from fixed to absolute.