### PR TITLE
alpha release v0.1.7-rebuild

### DIFF
--- a/src/components/restore-backup-dialog.tsx
+++ b/src/components/restore-backup-dialog.tsx
@@ -78,7 +78,7 @@ export function RestoreBackupDialog({
 
       setSelectedPath(backupPath);
 
-      let metadata: BackupMetadata = {
+      const metadata: BackupMetadata = {
         date: handleDateConversion(result.data.date),
         number_of_worlds: result.data.number_of_worlds,
         number_of_folders: result.data.number_of_folders,


### PR DESCRIPTION
This pull request includes a minor refactor in the `RestoreBackupDialog` component by changing the `metadata` variable from `let` to `const` for better immutability and code clarity.

* [`src/components/restore-backup-dialog.tsx`](diffhunk://#diff-24146b42b6076143c832cc2aee36dbaea4932b4d9a1bd1c8c03577a241c8b62dL81-R81): Updated the `metadata` variable declaration to use `const` instead of `let` in the `RestoreBackupDialog` function.