### PR TITLE
remove missed npm dependency in tauri.conf.json

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "frontendDist": "../out",
     "devUrl": "http://localhost:3000",
-    "beforeDevCommand": "npm run dev",
-    "beforeBuildCommand": "npm run build"
+    "beforeDevCommand": "bun run dev",
+    "beforeBuildCommand": "bun run build"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
This pull request updates the build configuration in `src-tauri/tauri.conf.json` to use the `bun` package manager instead of `npm` for development and build commands.

Build configuration updates:

* [`src-tauri/tauri.conf.json`](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L9-R10): Replaced `npm run dev` with `bun run dev` for the `beforeDevCommand` and `npm run build` with `bun run build` for the `beforeBuildCommand`.
closes: #40 