### PR TITLE
check millisecond to reorder worlds correctly in dateAdded sort

### DIFF
--- a/src-tauri/src/definitions/entities.rs
+++ b/src-tauri/src/definitions/entities.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use reqwest::cookie::Jar;
 use serde::{Deserialize, Serialize};
 
@@ -114,8 +114,7 @@ impl WorldModel {
             date_added: self
                 .user_data
                 .date_added
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string(),
+                .to_rfc3339_opts(SecondsFormat::Millis, true),
             platform: if self
                 .api_data
                 .platform

--- a/src/components/world-grid.tsx
+++ b/src/components/world-grid.tsx
@@ -179,22 +179,10 @@ export function WorldGrid({
       case 'favorites':
         return multiplier * (a.favorites - b.favorites);
       case 'dateAdded': {
-        const getTimestamp = (dateStr: string | null) => {
-          if (!dateStr) return 0;
+        const dateA = a.dateAdded || '';
+        const dateB = b.dateAdded || '';
 
-          try {
-            const date = new Date(dateStr);
-            return date.getTime();
-          } catch (e) {
-            error(`Error parsing date: ${dateStr}, ${e}`);
-            return 0;
-          }
-        };
-
-        const dateA = getTimestamp(a.dateAdded);
-        const dateB = getTimestamp(b.dateAdded);
-
-        return multiplier * (dateA - dateB);
+        return multiplier * dateA.localeCompare(dateB);
       }
       case 'lastUpdated': {
         const getTimestamp = (dateStr: string | null) => {


### PR DESCRIPTION
This pull request introduces changes to improve date handling and simplify code logic in both the backend and frontend. The key updates include switching to a standardized date format in the backend and simplifying date comparison logic in the frontend.

### Backend changes (Rust):

* [`src-tauri/src/definitions/entities.rs`](diffhunk://#diff-b0c499b4abf478259a39b039a5a7364f84e9081bd741725af25d5c47166abcf2L1-R1): Updated the `chrono` library import to include `SecondsFormat` for more granular date formatting.
* [`impl WorldModel`](diffhunk://#diff-b0c499b4abf478259a39b039a5a7364f84e9081bd741725af25d5c47166abcf2L117-R117): Modified the `date_added` field to use `to_rfc3339_opts` with millisecond precision instead of a custom string format, ensuring consistency and adherence to the ISO 8601 standard.

### Frontend changes (TypeScript/React):

* [`src/components/world-grid.tsx`](diffhunk://#diff-15f9a6b18a99b9bfa39a4c7560d575d1ae49ca198d0db7150af4f9b0146663f8L182-R185): Simplified the date comparison logic in the `WorldGrid` component by replacing a custom timestamp conversion function with `localeCompare`, leveraging standardized string comparison for ISO 8601 date strings.

closes: #54