### PR TITLE
fix: reverse the order of favorite worlds to persist dateAdded order

### DIFF
--- a/src-tauri/src/commands/api_commands.rs
+++ b/src-tauri/src/commands/api_commands.rs
@@ -72,6 +72,9 @@ pub async fn get_favorite_worlds() -> Result<(), String> {
 
     log::info!("Received worlds: {:#?}", worlds); // Debug print the worlds
 
+    // Reverse the order to preserve the original date added order
+    let worlds = worlds.into_iter().rev().collect::<Vec<_>>();
+
     match FolderManager::add_worlds(WORLDS.get(), worlds) {
         Ok(_) => Ok(()),
         Err(e) => {


### PR DESCRIPTION
This pull request includes a small change to the `get_favorite_worlds` function in the `src-tauri/src/commands/api_commands.rs` file. The change reverses the order of the `worlds` collection to preserve the original date-added order before processing it.

Closes #57