### PR TITLE
fix: github and discord link will be opened using webview

### DIFF
--- a/src/components/about-section.tsx
+++ b/src/components/about-section.tsx
@@ -192,33 +192,27 @@ export function AboutSection() {
           </div>
 
           <div className="flex gap-4">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="gap-2"
-              onClick={() =>
-                window.open(
-                  'https://github.com/Raifa21/vrc-world-manager',
-                  '_blank',
-                )
-              }
-            >
-              <SiGithub className="h-4 w-4" />
-              {t('about-section:source-code')}
+            <Button variant="ghost" size="sm" asChild>
+              <a
+                href="https://github.com/Raifa21/vrc-world-manager"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex flex-row gap-2"
+              >
+                <SiGithub className="h-4 w-4" />
+                {t('about-section:source-code')}
+              </a>
             </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="gap-2"
-              onClick={() =>
-                window.open(
-                  'https://github.com/Raifa21/vrc-world-manager/issues',
-                  '_blank',
-                )
-              }
-            >
-              <SiDiscord className="h-4 w-4" />
-              {t('about-section:report-issue')}
+            <Button variant="ghost" size="sm" asChild>
+              <a
+                href="https://discord.gg/gNzbpux5xW"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex flex-row gap-2"
+              >
+                <SiDiscord className="h-4 w-4" />
+                {t('about-section:report-issue')}
+              </a>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Overview
Fixed an issue where GitHub and Discord links would open in Webview and now open in the browser.
Also, the Discord button was incorrectly leading to the Issues page on GitHub, so that has been fixed as well.

## For Reviewer
Make sure the Discord link is the correct one and does not expire in the future.