### PR TITLE
style: improve text wrapping for world description in detail popup

### DIFF
--- a/src/components/world-detail-popup.tsx
+++ b/src/components/world-detail-popup.tsx
@@ -404,7 +404,7 @@ export function WorldDetailPopup({
                         <div className="text-sm font-semibold mb-2">
                           {t('world-detail:description')}
                         </div>
-                        <div className="text-sm">
+                        <div className="text-sm break-words overflow-wrap-anywhere">
                           {worldDetails.description}
                         </div>
                       </div>


### PR DESCRIPTION
This pull request includes a small change to the `WorldDetailPopup` component to improve the display of long text descriptions.

* [`src/components/world-detail-popup.tsx`](diffhunk://#diff-17394110ebbb0d64fe377464028a4a7a5038351554da910237dce4e56d5ec312L407-R407): Updated the `description` text container to include `break-words` and `overflow-wrap-anywhere` classes, ensuring that long text descriptions wrap properly and do not overflow the container.

Closes: #98