### PR TITLE
fix: reset state after group instance creation

### DIFF
--- a/src/components/group-instance-creator.tsx
+++ b/src/components/group-instance-creator.tsx
@@ -257,6 +257,17 @@ export function GroupInstanceCreator({
       stepInfo.queueEnabled,
       rolesToPass,
     );
+
+    // Reset state after creation
+    setCurrentStep('group');
+    setIsLoading(false);
+    setStepInfo({
+      groupId: null,
+      instanceType: null,
+      region: 'JP',
+      queueEnabled: false,
+      selectedRoles: new Set(),
+    });
   };
 
   const handleInstanceTypeSelect = (type: GroupInstanceType) => {

--- a/src/components/world-detail-popup.tsx
+++ b/src/components/world-detail-popup.tsx
@@ -214,6 +214,8 @@ export function WorldDetailPopup({
       queueEnabled,
       selectedRoles,
     );
+    // Reset state after creating instance
+    setInstanceCreationType('normal');
     onOpenChange(false); // Close dialog after creating instance
   };
 


### PR DESCRIPTION
This pull request introduces state reset functionality to ensure proper cleanup after creating instances in two different components. The changes focus on improving user experience and maintaining consistent application state.

**State Reset Enhancements:**

* [`src/components/group-instance-creator.tsx`](diffhunk://#diff-1e57e11f64f6f08d5bb4ad1499866b3d4402e309dad3185179cb40500eb4d207R260-R270): Added a state reset after creating a group instance, including resetting the current step, loading state, and step information such as `groupId`, `instanceType`, `region`, `queueEnabled`, and `selectedRoles`.
* [`src/components/world-detail-popup.tsx`](diffhunk://#diff-17394110ebbb0d64fe377464028a4a7a5038351554da910237dce4e56d5ec312R217-R218): Updated the logic to reset the `instanceCreationType` state to `'normal'` after creating an instance and ensured the dialog is closed by invoking `onOpenChange(false)`.

Closes : #108 