### PR TITLE
fix: update GitHub link in AboutSection component

### DIFF
--- a/src/components/about-section.tsx
+++ b/src/components/about-section.tsx
@@ -219,7 +219,7 @@ export function AboutSection() {
           <div className="flex gap-4">
             <Button variant="ghost" size="sm" asChild>
               <a
-                href="https://github.com/Raifa21/vrc-world-manager"
+                href="https://github.com/Raifa21/vrc-worlds-manager-v2"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex flex-row gap-2"


### PR DESCRIPTION
This pull request includes a minor update to the `AboutSection` component. The change updates the GitHub repository link to point to the correct URL for version 2 of the project.

* [`src/components/about-section.tsx`](diffhunk://#diff-90f3bd7cb1d572de533be47281e35060ecb19fdb6d4ac1888ecdc196e62ad16cL222-R222): Updated the `href` attribute in the `<a>` tag to point to `https://github.com/Raifa21/vrc-worlds-manager-v2`, ensuring the link directs users to the latest version of the repository.
Closes: #170 