### PR TITLE
feat/add launch protocol logic to instance generation

### DIFF
--- a/src-tauri/src/commands/api_commands.rs
+++ b/src-tauri/src/commands/api_commands.rs
@@ -1,3 +1,6 @@
+use tauri::AppHandle;
+use tauri::State;
+
 use crate::api::group::GroupInstancePermissionInfo;
 use crate::api::group::UserGroup;
 use crate::definitions::WorldDetails;
@@ -205,6 +208,7 @@ pub async fn create_world_instance(
     world_id: String,
     instance_type_str: String,
     region_str: String,
+    handle: State<'_, AppHandle>,
 ) -> Result<(), String> {
     let cookie_store = AUTHENTICATOR.get().read().await.get_cookies();
     let user_id = INITSTATE.get().read().await.user_id.clone();
@@ -215,6 +219,7 @@ pub async fn create_world_instance(
         region_str,
         cookie_store,
         user_id,
+        (*handle).clone(),
     )
     .await;
 
@@ -274,6 +279,7 @@ pub async fn create_group_instance(
     allowed_roles: Option<Vec<String>>,
     region_str: String,
     queue_enabled: bool,
+    handle: State<'_, AppHandle>,
 ) -> Result<(), String> {
     let cookie_store = AUTHENTICATOR.get().read().await.get_cookies();
 
@@ -285,6 +291,7 @@ pub async fn create_group_instance(
         region_str,
         queue_enabled,
         cookie_store,
+        (*handle).clone(),
     )
     .await;
 

--- a/src-tauri/src/services/api_service.rs
+++ b/src-tauri/src/services/api_service.rs
@@ -358,7 +358,7 @@ impl ApiService {
         cookie_store: Arc<Jar>,
         world_id: String,
         instance_id: String,
-        app: &tauri::AppHandle,
+        app: AppHandle,
     ) -> Result<(), String> {
         match invite::invite_self_to_instance(cookie_store, &world_id, &instance_id).await {
             Ok(_) => {
@@ -556,7 +556,7 @@ impl ApiService {
                 // Invite self to the instance
                 let instance_id = _instance.instance_id.clone();
                 let world_id = _instance.world_id.clone();
-                Self::invite_self_to_instance(cookie_store, world_id, instance_id, &app).await?;
+                Self::invite_self_to_instance(cookie_store, world_id, instance_id, app).await?;
                 Ok(())
             }
             Err(e) => Err(format!("Failed to create world instance: {}", e)),
@@ -688,7 +688,7 @@ impl ApiService {
                 // Invite self to the instance
                 let instance_id = _instance.instance_id.clone();
                 let world_id = _instance.world_id.clone();
-                Self::invite_self_to_instance(cookie_store, world_id, instance_id, &app).await?;
+                Self::invite_self_to_instance(cookie_store, world_id, instance_id, app).await?;
                 Ok(())
             }
             Err(e) => Err(format!("Failed to create group instance: {}", e)),


### PR DESCRIPTION
This pull request introduces changes to integrate the `AppHandle` into API commands and services, enabling the application to open VRChat instances directly in the user's client. The key updates involve passing the `AppHandle` through various methods and leveraging it to construct and open URLs for VRChat instance launches.

### Integration of `AppHandle` for VRChat instance launching:

* **API Commands (`src-tauri/src/commands/api_commands.rs`)**:
  - Added `AppHandle` as a parameter to the `create_world_instance` and `create_group_instance` functions, enabling the API commands to pass the application handle downstream. [[1]](diffhunk://#diff-6344f805cc3a72149147e3e360962928ffc4224b8764d429b9ae8afd1a78e47cR211) [[2]](diffhunk://#diff-6344f805cc3a72149147e3e360962928ffc4224b8764d429b9ae8afd1a78e47cR282)
  - Updated the function calls to include the cloned `AppHandle` when invoking downstream methods. [[1]](diffhunk://#diff-6344f805cc3a72149147e3e360962928ffc4224b8764d429b9ae8afd1a78e47cR222) [[2]](diffhunk://#diff-6344f805cc3a72149147e3e360962928ffc4224b8764d429b9ae8afd1a78e47cR294)

* **API Service (`src-tauri/src/services/api_service.rs`)**:
  - Added `AppHandle` as a parameter to the `create_world_instance` and `create_group_instance` methods, as well as the `invite_self_to_instance` method. [[1]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736R522) [[2]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736R635) [[3]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736R361-R377)
  - Modified `invite_self_to_instance` to construct a VRChat URL (`vrchat://launch`) and use the `AppHandle` to open the URL in the user's client. Added logging for success and error scenarios. [[1]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736R14-R15) [[2]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736R361-R377)
  - Updated calls to `invite_self_to_instance` to include the `AppHandle`, ensuring the instance launching functionality is utilized. [[1]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L542-R559) [[2]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L673-R691)

Closes: #199 