### PR TITLE
Fix/add short name to launch option

### DIFF
--- a/src-tauri/src/api/instance/definitions.rs
+++ b/src-tauri/src/api/instance/definitions.rs
@@ -185,3 +185,11 @@ pub struct Instance {
     #[serde(rename = "worldId")]
     pub world_id: String,
 }
+
+#[derive(Debug, Deserialize)]
+pub struct GetInstanceShortNameResponse {
+    #[serde(rename = "secureName")]
+    pub secure_name: String,
+    #[serde(rename = "shortName")]
+    pub short_name: Option<String>,
+}

--- a/src-tauri/src/api/instance/logic.rs
+++ b/src-tauri/src/api/instance/logic.rs
@@ -117,9 +117,5 @@ pub async fn get_instance_short_name<J: Into<Arc<Jar>>>(
     };
 
     // if short name is None, return the secure name
-    if parsed.short_name.is_none() {
-        Ok(parsed.secure_name)
-    } else {
-        Ok(parsed.short_name.unwrap())
-    }
+    Ok(parsed.short_name.unwrap_or(parsed.secure_name))
 }

--- a/src-tauri/src/api/instance/logic.rs
+++ b/src-tauri/src/api/instance/logic.rs
@@ -2,9 +2,13 @@ use std::sync::Arc;
 
 use reqwest::cookie::Jar;
 
-use crate::api::common::{
-    check_rate_limit, get_reqwest_client, handle_api_response, record_rate_limit, reset_backoff,
-    API_BASE_URL,
+use crate::api::{
+    common::{
+        check_rate_limit, get_reqwest_client, handle_api_response, record_rate_limit,
+        reset_backoff, API_BASE_URL,
+    },
+    instance::definitions::GetInstanceShortNameResponse,
+    world,
 };
 
 use super::definitions::{CreateInstanceRequest, Instance};
@@ -61,4 +65,61 @@ pub async fn create_instance<J: Into<Arc<Jar>>>(
     };
 
     Ok(parsed)
+}
+
+pub async fn get_instance_short_name<J: Into<Arc<Jar>>>(
+    cookie: J,
+    world_id: &str,
+    instance_id: &str,
+) -> Result<String, String> {
+    const OPERATION: &str = "get_instance_short_name";
+
+    check_rate_limit(OPERATION)?;
+
+    let cookie_jar: Arc<Jar> = cookie.into();
+    let client = get_reqwest_client(&cookie_jar);
+
+    let url = format!("{API_BASE_URL}/instances/{world_id}:{instance_id}/shortName");
+    let result = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to send get instance short name request: {}", e))?;
+
+    let result = match handle_api_response(result, OPERATION).await {
+        Ok(response) => response,
+        Err(e) => {
+            log::error!("Failed to handle API response: {}", e);
+            record_rate_limit(OPERATION);
+            return Err(e);
+        }
+    };
+
+    reset_backoff(OPERATION);
+
+    let text = result
+        .text()
+        .await
+        .map_err(|e| format!("Failed to get instance short name: {}", e.to_string()))?;
+    let parsed: GetInstanceShortNameResponse = match serde_json::from_str(&text) {
+        Ok(response) => response,
+        Err(e) => {
+            log::info!(
+                "Failed to parse get instance short name response: {}",
+                e.to_string()
+            );
+            log::info!("Response: {text}");
+            return Err(format!(
+                "Failed to parse get instance short name response: {}",
+                e.to_string()
+            ));
+        }
+    };
+
+    // if short name is None, return the secure name
+    if parsed.short_name.is_none() {
+        Ok(parsed.secure_name)
+    } else {
+        Ok(parsed.short_name.unwrap())
+    }
 }

--- a/src-tauri/src/api/instance/mod.rs
+++ b/src-tauri/src/api/instance/mod.rs
@@ -8,3 +8,4 @@ pub use definitions::InstanceRegion;
 pub use definitions::InstanceType;
 
 pub use logic::create_instance;
+pub use logic::get_instance_short_name;

--- a/src-tauri/src/services/api_service.rs
+++ b/src-tauri/src/services/api_service.rs
@@ -724,7 +724,21 @@ impl ApiService {
                 // Invite self to the instance
                 let instance_id = _instance.instance_id.clone();
                 let world_id = _instance.world_id.clone();
-                Self::invite_self_to_instance(cookie_store, world_id, instance_id).await?;
+                Self::invite_self_to_instance(
+                    cookie_store.clone(),
+                    world_id.clone(),
+                    instance_id.clone(),
+                )
+                .await?;
+                // DISABLED: until VRChat updates to open the instance menu
+
+                // Self::get_instance_short_name_and_open_client(
+                //     cookie_store,
+                //     &world_id,
+                //     &instance_id,
+                //     app,
+                // )
+                // .await?;
                 Ok(())
             }
             Err(e) => Err(format!("Failed to create group instance: {}", e)),


### PR DESCRIPTION
This pull request introduces functionality to retrieve the short name of an instance and includes updates to API logic and service methods to support this feature. The key changes involve adding a new API call, updating the `ApiService` methods, and temporarily disabling a feature dependent on external updates.

### API Enhancements:
* Added a new struct `GetInstanceShortNameResponse` to represent the response for retrieving an instance's short name, with fields for `secure_name` and an optional `short_name`. (`src-tauri/src/api/instance/definitions.rs`: [src-tauri/src/api/instance/definitions.rsR188-R195](diffhunk://#diff-19a15167f8a8e75ba3f5740a780044447135bb2c38556460edf53b0b27decc45R188-R195))
* Implemented the `get_instance_short_name` function to fetch the short name of an instance via the API, falling back to the secure name if the short name is unavailable. (`src-tauri/src/api/instance/logic.rs`: [src-tauri/src/api/instance/logic.rsR69-R125](diffhunk://#diff-ed35e269e4b02bb3f338c4c26b6ee8cd77a1024932e354ee0bf648cba428d08eR69-R125))
* Exposed the `get_instance_short_name` function in the module's public API. (`src-tauri/src/api/instance/mod.rs`: [src-tauri/src/api/instance/mod.rsR11](diffhunk://#diff-feaeabe3796ee5929d3efca3c1c981e7384d1e8f35a7fda8baa4743137330bacR11))

### Service Updates:
* Added a new method `get_instance_short_name_and_open_client` in `ApiService` to retrieve the instance short name and open the instance menu in the user's client. (`src-tauri/src/services/api_service.rs`: [src-tauri/src/services/api_service.rsL361-R399](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L361-R399))
* Updated existing methods to prepare for integrating the new functionality but temporarily disabled the feature until external updates are available. (`src-tauri/src/services/api_service.rs`: [[1]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L559-R595) [[2]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L691-R741)

Closes: #202 