### PR TITLE
pre-release v1.1.1-rc.3

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "1.1.1-rc.2",
+    "preRelease": true,
+    "features": [
+      {
+        "text": "Creating instance now opens instance menu page following VRChat client update",
+        "langs": [
+          {
+            "lang": ["ja-JP"],
+            "text": "インスタンスを作成すると、VRChatクライアントの更新に伴いインスタンスメニューが開くようになりました"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "version": "1.1.1-rc.1",
     "preRelease": true,
     "features": [

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "1.1.1-rc.3",
+    "preRelease": true,
+    "fixes": [
+      {
+        "text": "Undo opening VRChat client when creating instance as VRChat has yet to update to implement this feature",
+        "langs": [
+          {
+            "lang": ["ja-JP"],
+            "text": "VRChatクライアントがこの機能を実装していないため、インスタンスを生成する際にVRChatクライアントを開く機能を元に戻しました"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "version": "1.1.1-rc.2",
     "preRelease": true,
     "features": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vrc-world-manager",
-  "version": "1.1.1-rc.1",
+  "version": "1.1.1-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vrc-world-manager",
-      "version": "1.1.1-rc.1",
+      "version": "1.1.1-rc.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vrc-world-manager",
-  "version": "1.1.1-rc.2",
+  "version": "1.1.1-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vrc-world-manager",
-      "version": "1.1.1-rc.2",
+      "version": "1.1.1-rc.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vrc-world-manager",
-  "version": "1.1.1-rc.2",
+  "version": "1.1.1-rc.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vrc-world-manager",
-  "version": "1.1.1-rc.1",
+  "version": "1.1.1-rc.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5741,7 +5741,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vrc-worlds-manager"
-version = "1.1.1-rc.1"
+version = "1.1.1-rc.2"
 dependencies = [
  "aes",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5741,7 +5741,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vrc-worlds-manager"
-version = "1.1.1-rc.2"
+version = "1.1.1-rc.3"
 dependencies = [
  "aes",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrc-worlds-manager"
-version = "1.1.1-rc.1"
+version = "1.1.1-rc.2"
 description = "A Tauri App"
 authors = ["Raifa", "siloneco"]
 license = ""

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrc-worlds-manager"
-version = "1.1.1-rc.2"
+version = "1.1.1-rc.3"
 description = "A Tauri App"
 authors = ["Raifa", "siloneco"]
 license = ""

--- a/src-tauri/src/api/common.rs
+++ b/src-tauri/src/api/common.rs
@@ -9,7 +9,7 @@ use crate::RATE_LIMIT_STORE;
 
 pub const API_BASE_URL: &str = "https://api.vrchat.cloud/api/1";
 
-const USER_AGENT: &str = "VRC Worlds Manager v2 (tauri)/1.1.1-rc.1 discord:raifa";
+const USER_AGENT: &str = "VRC Worlds Manager v2 (tauri)/1.1.1-rc.2 discord:raifa";
 
 pub fn get_reqwest_client(cookies: &Arc<Jar>) -> reqwest::Client {
     reqwest::ClientBuilder::new()

--- a/src-tauri/src/api/common.rs
+++ b/src-tauri/src/api/common.rs
@@ -9,7 +9,7 @@ use crate::RATE_LIMIT_STORE;
 
 pub const API_BASE_URL: &str = "https://api.vrchat.cloud/api/1";
 
-const USER_AGENT: &str = "VRC Worlds Manager v2 (tauri)/1.1.1-rc.2 discord:raifa";
+const USER_AGENT: &str = "VRC Worlds Manager v2 (tauri)/1.1.1-rc.3 discord:raifa";
 
 pub fn get_reqwest_client(cookies: &Arc<Jar>) -> reqwest::Client {
     reqwest::ClientBuilder::new()

--- a/src-tauri/src/api/instance/definitions.rs
+++ b/src-tauri/src/api/instance/definitions.rs
@@ -185,3 +185,11 @@ pub struct Instance {
     #[serde(rename = "worldId")]
     pub world_id: String,
 }
+
+#[derive(Debug, Deserialize)]
+pub struct GetInstanceShortNameResponse {
+    #[serde(rename = "secureName")]
+    pub secure_name: String,
+    #[serde(rename = "shortName")]
+    pub short_name: Option<String>,
+}

--- a/src-tauri/src/api/instance/logic.rs
+++ b/src-tauri/src/api/instance/logic.rs
@@ -2,9 +2,13 @@ use std::sync::Arc;
 
 use reqwest::cookie::Jar;
 
-use crate::api::common::{
-    check_rate_limit, get_reqwest_client, handle_api_response, record_rate_limit, reset_backoff,
-    API_BASE_URL,
+use crate::api::{
+    common::{
+        check_rate_limit, get_reqwest_client, handle_api_response, record_rate_limit,
+        reset_backoff, API_BASE_URL,
+    },
+    instance::definitions::GetInstanceShortNameResponse,
+    world,
 };
 
 use super::definitions::{CreateInstanceRequest, Instance};
@@ -61,4 +65,57 @@ pub async fn create_instance<J: Into<Arc<Jar>>>(
     };
 
     Ok(parsed)
+}
+
+pub async fn get_instance_short_name<J: Into<Arc<Jar>>>(
+    cookie: J,
+    world_id: &str,
+    instance_id: &str,
+) -> Result<String, String> {
+    const OPERATION: &str = "get_instance_short_name";
+
+    check_rate_limit(OPERATION)?;
+
+    let cookie_jar: Arc<Jar> = cookie.into();
+    let client = get_reqwest_client(&cookie_jar);
+
+    let url = format!("{API_BASE_URL}/instances/{world_id}:{instance_id}/shortName");
+    let result = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to send get instance short name request: {}", e))?;
+
+    let result = match handle_api_response(result, OPERATION).await {
+        Ok(response) => response,
+        Err(e) => {
+            log::error!("Failed to handle API response: {}", e);
+            record_rate_limit(OPERATION);
+            return Err(e);
+        }
+    };
+
+    reset_backoff(OPERATION);
+
+    let text = result
+        .text()
+        .await
+        .map_err(|e| format!("Failed to get instance short name: {}", e.to_string()))?;
+    let parsed: GetInstanceShortNameResponse = match serde_json::from_str(&text) {
+        Ok(response) => response,
+        Err(e) => {
+            log::info!(
+                "Failed to parse get instance short name response: {}",
+                e.to_string()
+            );
+            log::info!("Response: {text}");
+            return Err(format!(
+                "Failed to parse get instance short name response: {}",
+                e.to_string()
+            ));
+        }
+    };
+
+    // if short name is None, return the secure name
+    Ok(parsed.short_name.unwrap_or(parsed.secure_name))
 }

--- a/src-tauri/src/api/instance/mod.rs
+++ b/src-tauri/src/api/instance/mod.rs
@@ -8,3 +8,4 @@ pub use definitions::InstanceRegion;
 pub use definitions::InstanceType;
 
 pub use logic::create_instance;
+pub use logic::get_instance_short_name;

--- a/src-tauri/src/commands/api_commands.rs
+++ b/src-tauri/src/commands/api_commands.rs
@@ -1,3 +1,6 @@
+use tauri::AppHandle;
+use tauri::State;
+
 use crate::api::group::GroupInstancePermissionInfo;
 use crate::api::group::UserGroup;
 use crate::definitions::WorldDetails;
@@ -205,6 +208,7 @@ pub async fn create_world_instance(
     world_id: String,
     instance_type_str: String,
     region_str: String,
+    handle: State<'_, AppHandle>,
 ) -> Result<(), String> {
     let cookie_store = AUTHENTICATOR.get().read().await.get_cookies();
     let user_id = INITSTATE.get().read().await.user_id.clone();
@@ -215,6 +219,7 @@ pub async fn create_world_instance(
         region_str,
         cookie_store,
         user_id,
+        (*handle).clone(),
     )
     .await;
 
@@ -274,6 +279,7 @@ pub async fn create_group_instance(
     allowed_roles: Option<Vec<String>>,
     region_str: String,
     queue_enabled: bool,
+    handle: State<'_, AppHandle>,
 ) -> Result<(), String> {
     let cookie_store = AUTHENTICATOR.get().read().await.get_cookies();
 
@@ -285,6 +291,7 @@ pub async fn create_group_instance(
         region_str,
         queue_enabled,
         cookie_store,
+        (*handle).clone(),
     )
     .await;
 

--- a/src-tauri/src/services/api_service.rs
+++ b/src-tauri/src/services/api_service.rs
@@ -365,7 +365,7 @@ impl ApiService {
         }
     }
 
-    // Get the instance short name, and open the instance menu in the user's client
+    /// Get the instance short name, and open the instance menu in the user's client
     ///
     /// # Arguments
     /// * `cookie` - The cookie jar to use for the API

--- a/src-tauri/src/services/api_service.rs
+++ b/src-tauri/src/services/api_service.rs
@@ -358,25 +358,45 @@ impl ApiService {
         cookie_store: Arc<Jar>,
         world_id: String,
         instance_id: String,
-        app: AppHandle,
     ) -> Result<(), String> {
         match invite::invite_self_to_instance(cookie_store, &world_id, &instance_id).await {
-            Ok(_) => {
-                // open the instance in the user's client
-                // using vrchat://launch?ref=vrchat.com&id={world_id}:{instance_id}
-                let url = format!(
-                    "vrchat://launch?ref=vrchat.com&id={}:{}",
-                    world_id, instance_id
-                );
-                log::info!("Opening instance in client: {}", url);
-                app.opener().open_url(&url, None::<String>).map_err(|e| {
-                    log::error!("Failed to open instance in client: {}", e);
-                    format!("Failed to open instance in client: {}", e)
-                })?;
-                Ok(())
-            }
+            Ok(_) => Ok(()),
             Err(e) => Err(format!("Failed to invite self to instance: {}", e)),
         }
+    }
+
+    // Get the instance short name, and open the instance menu in the user's client
+    ///
+    /// # Arguments
+    /// * `cookie` - The cookie jar to use for the API
+    /// * `world_id` - The ID of the world to get the instance short name
+    /// * `instance_id` - The ID of the instance to get the short name for
+    /// * `app` - The AppHandle to use for opening the instance in the user's client
+    ///
+    /// # Returns
+    /// Returns a Result containing the short name of the instance if the request was successful
+    ///
+    /// # Errors
+    /// Returns a string error message if the request fails
+    pub async fn get_instance_short_name_and_open_client<J: Into<Arc<Jar>>>(
+        cookie: J,
+        world_id: &str,
+        instance_id: &str,
+        app: AppHandle,
+    ) -> Result<String, String> {
+        let short_name = instance::get_instance_short_name(cookie, world_id, instance_id).await?;
+
+        // Open the instance in the user's client
+        let url = format!(
+            "vrchat://launch?ref=vrchat.com&id={}:{}&shortName={}",
+            world_id, instance_id, short_name
+        );
+        log::info!("Opening instance in client: {}", url);
+        app.opener().open_url(&url, None::<String>).map_err(|e| {
+            log::error!("Failed to open instance in client: {}", e);
+            format!("Failed to open instance in client: {}", e)
+        })?;
+        Ok(short_name)
     }
 
     /// Get the user's recently visited worlds  
@@ -556,7 +576,23 @@ impl ApiService {
                 // Invite self to the instance
                 let instance_id = _instance.instance_id.clone();
                 let world_id = _instance.world_id.clone();
-                Self::invite_self_to_instance(cookie_store, world_id, instance_id, app).await?;
+                Self::invite_self_to_instance(
+                    cookie_store.clone(),
+                    world_id.clone(),
+                    instance_id.clone(),
+                )
+                .await?;
+
+                // DISABLED: until VRChat updates to open the instance menu
+
+                // Self::get_instance_short_name_and_open_client(
+                //     cookie_store,
+                //     &world_id,
+                //     &instance_id,
+                //     app,
+                // )
+                // .await?;
+
                 Ok(())
             }
             Err(e) => Err(format!("Failed to create world instance: {}", e)),
@@ -688,7 +724,21 @@ impl ApiService {
                 // Invite self to the instance
                 let instance_id = _instance.instance_id.clone();
                 let world_id = _instance.world_id.clone();
-                Self::invite_self_to_instance(cookie_store, world_id, instance_id, app).await?;
+                Self::invite_self_to_instance(
+                    cookie_store.clone(),
+                    world_id.clone(),
+                    instance_id.clone(),
+                )
+                .await?;
+                // DISABLED: until VRChat updates to open the instance menu
+
+                // Self::get_instance_short_name_and_open_client(
+                //     cookie_store,
+                //     &world_id,
+                //     &instance_id,
+                //     app,
+                // )
+                // .await?;
                 Ok(())
             }
             Err(e) => Err(format!("Failed to create group instance: {}", e)),

--- a/src-tauri/src/services/api_service.rs
+++ b/src-tauri/src/services/api_service.rs
@@ -11,6 +11,8 @@ use reqwest::cookie::CookieStore;
 use reqwest::{cookie::Jar, Client, Url};
 use std::sync::{Arc, RwLock};
 use tauri::http::HeaderValue;
+use tauri::AppHandle;
+use tauri_plugin_opener::OpenerExt;
 use world::ReleaseStatus;
 
 pub struct ApiService;
@@ -356,9 +358,23 @@ impl ApiService {
         cookie_store: Arc<Jar>,
         world_id: String,
         instance_id: String,
+        app: AppHandle,
     ) -> Result<(), String> {
         match invite::invite_self_to_instance(cookie_store, &world_id, &instance_id).await {
-            Ok(_) => Ok(()),
+            Ok(_) => {
+                // open the instance in the user's client
+                // using vrchat://launch?ref=vrchat.com&id={world_id}:{instance_id}
+                let url = format!(
+                    "vrchat://launch?ref=vrchat.com&id={}:{}",
+                    world_id, instance_id
+                );
+                log::info!("Opening instance in client: {}", url);
+                app.opener().open_url(&url, None::<String>).map_err(|e| {
+                    log::error!("Failed to open instance in client: {}", e);
+                    format!("Failed to open instance in client: {}", e)
+                })?;
+                Ok(())
+            }
             Err(e) => Err(format!("Failed to invite self to instance: {}", e)),
         }
     }
@@ -503,6 +519,7 @@ impl ApiService {
         region_str: String,
         cookie_store: Arc<Jar>,
         user_id: String,
+        app: AppHandle,
     ) -> Result<(), String> {
         log::info!(
             "Creating instance: {} {} {}",
@@ -539,7 +556,7 @@ impl ApiService {
                 // Invite self to the instance
                 let instance_id = _instance.instance_id.clone();
                 let world_id = _instance.world_id.clone();
-                Self::invite_self_to_instance(cookie_store, world_id, instance_id).await?;
+                Self::invite_self_to_instance(cookie_store, world_id, instance_id, app).await?;
                 Ok(())
             }
             Err(e) => Err(format!("Failed to create world instance: {}", e)),
@@ -615,6 +632,7 @@ impl ApiService {
         region_str: String,
         queue_enabled: bool,
         cookie_store: Arc<Jar>,
+        app: AppHandle,
     ) -> Result<(), String> {
         log::info!(
             "Creating group instance: {} {} {} {} {:?}",
@@ -670,7 +688,7 @@ impl ApiService {
                 // Invite self to the instance
                 let instance_id = _instance.instance_id.clone();
                 let world_id = _instance.world_id.clone();
-                Self::invite_self_to_instance(cookie_store, world_id, instance_id).await?;
+                Self::invite_self_to_instance(cookie_store, world_id, instance_id, app).await?;
                 Ok(())
             }
             Err(e) => Err(format!("Failed to create group instance: {}", e)),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "vrc-worlds-manager",
-  "version": "1.1.1-rc.2",
+  "version": "1.1.1-rc.3",
   "identifier": "com.raifaworks.vrc-worlds-manager",
   "build": {
     "frontendDist": "../out",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "vrc-worlds-manager",
-  "version": "1.1.1-rc.1",
+  "version": "1.1.1-rc.2",
   "identifier": "com.raifaworks.vrc-worlds-manager",
   "build": {
     "frontendDist": "../out",

--- a/src/components/about-section.tsx
+++ b/src/components/about-section.tsx
@@ -213,7 +213,7 @@ export function AboutSection() {
       <div className="w-full border-t bg-background/80 backdrop-blur-sm">
         <div className="container mx-auto px-4 py-2 flex justify-between items-center">
           <div className="text-sm text-muted-foreground">
-            VRC Worlds Manager v2 1.1.1-rc.1
+            VRC Worlds Manager v2 1.1.1-rc.2
           </div>
 
           <div className="flex gap-4">

--- a/src/components/about-section.tsx
+++ b/src/components/about-section.tsx
@@ -213,7 +213,7 @@ export function AboutSection() {
       <div className="w-full border-t bg-background/80 backdrop-blur-sm">
         <div className="container mx-auto px-4 py-2 flex justify-between items-center">
           <div className="text-sm text-muted-foreground">
-            VRC Worlds Manager v2 1.1.1-rc.2
+            VRC Worlds Manager v2 1.1.1-rc.3
           </div>
 
           <div className="flex gap-4">


### PR DESCRIPTION
This pull request introduces functionality to retrieve an instance's short name from the API and prepares the system to use this short name for launching instances in the VRChat client. The changes include defining a new response structure, implementing a new API call, and updating the `ApiService` to incorporate this functionality, though some features are currently disabled pending upstream updates.

### New functionality for retrieving instance short names:

* Added a new struct `GetInstanceShortNameResponse` in `src-tauri/src/api/instance/definitions.rs` to parse the API response for retrieving an instance's short name.
* Implemented the `get_instance_short_name` function in `src-tauri/src/api/instance/logic.rs` to fetch the short name of an instance using the API. This function handles rate limits, API responses, and fallback logic for missing short names.
* Exported the `get_instance_short_name` function in `src-tauri/src/api/instance/mod.rs` for use across the application.

### Updates to `ApiService` for short name integration:

* Added a new method `get_instance_short_name_and_open_client` in `src-tauri/src/services/api_service.rs`. This method retrieves the instance short name and constructs a URL to open the instance menu in the VRChat client, including the short name as a parameter.
* Updated existing methods in `ApiService` to prepare for integrating the short name functionality. However, the calls to `get_instance_short_name_and_open_client` are currently commented out until VRChat updates to support opening the instance menu with short names. [[1]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L559-R595) [[2]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L691-R741)