### PR TITLE
fix: add missing urlencode in login with password

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5662,6 +5662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5777,6 +5783,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "urlencoding",
  "uuid",
  "wiremock",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,7 @@ tauri-plugin-deep-link = "2"
 opener = "0.8.2"
 semver = "1.0.26"
 uuid = "1.17.0"
+urlencoding = "2.1.3"
 
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/src/api/auth/logic.rs
+++ b/src-tauri/src/api/auth/logic.rs
@@ -295,7 +295,9 @@ impl VRChatAPIClientAuthenticator {
     }
 
     fn generate_auth_header<S: AsRef<str>>(&self, password: S) -> String {
-        let auth_value = format!("{}:{}", self.username, password.as_ref());
+        let uriencoded_username = urlencoding::encode(&self.username);
+        let uriencoded_password = urlencoding::encode(password.as_ref());
+        let auth_value = format!("{}:{}", uriencoded_username, uriencoded_password);
         let encoded_value = BASE64_STANDARD.encode(auth_value);
         format!("Basic {}", encoded_value)
     }


### PR DESCRIPTION
This pull request updates the authentication logic to improve security and standards compliance by URL-encoding credentials before base64 encoding, and adds a new dependency to support this functionality.

**Authentication logic improvements:**

* In `src-tauri/src/api/auth/logic.rs`, the `generate_auth_header` method now URL-encodes both the username and password before constructing the basic authentication header, ensuring proper encoding of special characters.

**Dependency management:**

* Added the `urlencoding` crate (version 2.1.3) to `src-tauri/Cargo.toml` to provide URL-encoding functionality for authentication.