### PR TITLE
fix: update export function to use worlds instead of folders and enha…

### DIFF
--- a/src-tauri/src/commands/data/write_data_commands.rs
+++ b/src-tauri/src/commands/data/write_data_commands.rs
@@ -33,8 +33,7 @@ pub async fn restore_from_backup(backup_path: String) -> Result<(), String> {
 #[tauri::command]
 #[specta::specta]
 pub fn export_to_portal_library_system(folders: Vec<String>) -> Result<(), String> {
-    ExportService::export_to_portal_library_system(folders, FOLDERS.get())
-        .map_err(|e| e.to_string())
+    ExportService::export_to_portal_library_system(folders, WORLDS.get()).map_err(|e| e.to_string())
 }
 
 #[tauri::command]


### PR DESCRIPTION
This pull request refactors and expands the export functionality for the Portal Library System, mainly by switching the data source from folders to worlds and enriching the exported world data. The changes update the data model to include more detailed world information and platform support, and adjust the export logic accordingly.

**Export data model improvements:**

* Added the `PLSPlatform` struct to represent platform support (`pc`, `android`, and `ios`) for exported worlds, and updated the world export struct to include more detailed fields such as `id`, `name`, `recommended_capacity`, `capacity`, and `description` (`src-tauri/src/services/export_service.rs`).

**Export logic refactoring:**

* Changed the main export function to use `WorldModel` data instead of `FolderModel`, updating the function signature and internal logic to fetch and process worlds grouped by folders, and to build enriched export categories with platform details (`src-tauri/src/services/export_service.rs`).
* Updated the command handler to pass `WORLDS.get()` instead of `FOLDERS.get()` to the export service, reflecting the new data source (`src-tauri/src/commands/data/write_data_commands.rs`).…nce data structure