### PR TITLE
Feat/re open instance details

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -99,6 +99,7 @@
   "setup-page:migration-exists-cancel": "Keep existing data",
   "setup-page:migration-exists-continue": "Import new data",
 
+  "listview-page:open-in-client": "Open in VRChat",
   "listview-page:reloading-worlds": "Getting favorite worlds...",
   "listview-page:importing-folder": "Importing folder...",
   "listview-page:share-folder": "Share Folder",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -98,6 +98,7 @@
   "setup-page:migration-exists-cancel": "既存データを保持する",
   "setup-page:migration-exists-continue": "新しいデータをインポートする",
 
+  "listview-page:open-in-client": "VRChatで開く",
   "listview-page:reloading-worlds": "お気に入りのワールドを取得中...",
   "listview-page:importing-folder": "フォルダをインポート中...",
   "listview-page:share-folder": "フォルダを共有",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -70,6 +70,7 @@ pub fn generate_tauri_specta_builder() -> Builder<tauri::Wry> {
         api_commands::get_user_groups,
         api_commands::get_permission_for_create_group_instance,
         api_commands::create_group_instance,
+        api_commands::open_instance_in_client,
         open_folder_commands::open_logs_directory,
         open_folder_commands::open_folder_directory,
         data::read_data_commands::require_initial_setup,

--- a/src/app/listview/components/popups/world-details/hook.tsx
+++ b/src/app/listview/components/popups/world-details/hook.tsx
@@ -26,8 +26,26 @@ export function useWorldDetailsActions(onOpenChange: (open: boolean) => void) {
         toast(t('general:error-title'), { description: result.error });
         return;
       }
+      // result.data contains InstanceInfo with world_id, instance_id, short_name
+      const info = result.data;
       toast(t('general:success-title'), {
         description: t('listview-page:created-instance', instanceType),
+        action: {
+          label: t('listview-page:open-in-client'),
+          onClick: async () => {
+            try {
+              const openRes = await commands.openInstanceInClient(
+                info.world_id,
+                info.instance_id,
+              );
+              if (openRes.status === 'error') {
+                toast(t('general:error-title'), { description: openRes.error });
+              }
+            } catch (e) {
+              error(`Failed to open instance in client: ${e}`);
+            }
+          },
+        },
       });
     } catch (e) {
       error(`Failed to create instance: ${e}`);
@@ -58,8 +76,25 @@ export function useWorldDetailsActions(onOpenChange: (open: boolean) => void) {
         toast(t('general:error-title'), { description: result.error });
         return;
       }
+      const info = result.data;
       toast(t('general:success-title'), {
         description: t('listview-page:created-instance', instanceType),
+        action: {
+          label: t('listview-page:open-in-client'),
+          onClick: async () => {
+            try {
+              const openRes = await commands.openInstanceInClient(
+                info.world_id,
+                info.instance_id,
+              );
+              if (openRes.status === 'error') {
+                toast(t('general:error-title'), { description: openRes.error });
+              }
+            } catch (e) {
+              error(`Failed to open instance in client: ${e}`);
+            }
+          },
+        },
       });
     } catch (e) {
       error(`Failed to create group instance: ${e}`);

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -11,7 +11,8 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme={theme as ToasterProps['theme']}
-      className="toaster group"
+      // Ensure the toasts render above popups and are clickable
+      className="toaster group z-[999999] pointer-events-auto"
       toastOptions={{
         classNames: {
           toast:

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -610,7 +610,7 @@ export const commands = {
     worldId: string,
     instanceTypeStr: string,
     regionStr: string,
-  ): Promise<Result<null, string>> {
+  ): Promise<Result<InstanceInfo, string>> {
     try {
       return {
         status: 'ok',
@@ -655,7 +655,7 @@ export const commands = {
     allowedRoles: string[] | null,
     regionStr: string,
     queueEnabled: boolean,
-  ): Promise<Result<null, string>> {
+  ): Promise<Result<InstanceInfo, string>> {
     try {
       return {
         status: 'ok',
@@ -666,6 +666,23 @@ export const commands = {
           allowedRoles,
           regionStr,
           queueEnabled,
+        }),
+      };
+    } catch (e) {
+      if (e instanceof Error) throw e;
+      else return { status: 'error', error: e as any };
+    }
+  },
+  async openInstanceInClient(
+    worldId: string,
+    instanceId: string,
+  ): Promise<Result<string, string>> {
+    try {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('open_instance_in_client', {
+          worldId,
+          instanceId,
         }),
       };
     } catch (e) {
@@ -972,6 +989,11 @@ export type GroupRole = {
   name: string;
   permissions: GroupPermission[];
   isManagementRole: boolean;
+};
+export type InstanceInfo = {
+  world_id: string;
+  instance_id: string;
+  short_name: string | null;
 };
 export type InstanceRegion = 'us' | 'use' | 'eu' | 'jp';
 export type LocalizedChanges = {


### PR DESCRIPTION
This pull request introduces a new feature that allows users to open a created VRChat instance directly in the VRChat client from the UI. It also refactors the backend and frontend code to return more detailed information about created instances, and improves error handling for instance creation. Additionally, minor UI and localization improvements are included.

### New "Open in VRChat" feature

* Added a new backend command (`open_instance_in_client`) and frontend action to open a created instance in the VRChat client, including a toast notification with an "Open in VRChat" button. (F015b2b1L297R297, Fc1f5846L754R754, [[1]](diffhunk://#diff-b070f95c54a91306b48b0e89f2496244923a1737de9af49688b33278c084e04cR29-R48) [[2]](diffhunk://#diff-b070f95c54a91306b48b0e89f2496244923a1737de9af49688b33278c084e04cR79-R97) [[3]](diffhunk://#diff-85c85298173073295d8b4b35a90c5a3a8a05e17e7c909e342087ce71f9d8439dR676-R692) [[4]](diffhunk://#diff-015ce0fec25af6404615a6dcc2bcba0ed110cfaf51a3ef7148142c0e579c5fbcR102) [[5]](diffhunk://#diff-0da4236a295442542ff062bc390a1f7b105247f6f2113035118cea63d1e89e44R101)

### Backend API improvements

* Refactored instance creation commands (`create_world_instance`, `create_group_instance`) to return an `InstanceInfo` object with `world_id`, `instance_id`, and optionally `short_name`, instead of just success/failure. [[1]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736R20-R27) [[2]](diffhunk://#diff-6344f805cc3a72149147e3e360962928ffc4224b8764d429b9ae8afd1a78e47cL212-R213) [[3]](diffhunk://#diff-6344f805cc3a72149147e3e360962928ffc4224b8764d429b9ae8afd1a78e47cL227-R228) [[4]](diffhunk://#diff-6344f805cc3a72149147e3e360962928ffc4224b8764d429b9ae8afd1a78e47cL283-R284) [[5]](diffhunk://#diff-6344f805cc3a72149147e3e360962928ffc4224b8764d429b9ae8afd1a78e47cL299-R319) [[6]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L543-R551) [[7]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L586-R620) [[8]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L672-R696) [[9]](diffhunk://#diff-9981ddb48ca6645c9bff1f1905bc73f78bcb2681c603cce36b484b593bc23736L733-R777) [[10]](diffhunk://#diff-85c85298173073295d8b4b35a90c5a3a8a05e17e7c909e342087ce71f9d8439dL613-R613) [[11]](diffhunk://#diff-85c85298173073295d8b4b35a90c5a3a8a05e17e7c909e342087ce71f9d8439dL658-R658) [[12]](diffhunk://#diff-85c85298173073295d8b4b35a90c5a3a8a05e17e7c909e342087ce71f9d8439dR993-R997)

* Improved error handling for instance types requiring a logged-in user, providing early errors if user ID is missing.

### Frontend bindings and types

* Updated frontend bindings to match new backend signatures and added the new `InstanceInfo` type. [[1]](diffhunk://#diff-85c85298173073295d8b4b35a90c5a3a8a05e17e7c909e342087ce71f9d8439dL613-R613) [[2]](diffhunk://#diff-85c85298173073295d8b4b35a90c5a3a8a05e17e7c909e342087ce71f9d8439dL658-R658) [[3]](diffhunk://#diff-85c85298173073295d8b4b35a90c5a3a8a05e17e7c909e342087ce71f9d8439dR993-R997)

### UI improvements

* Ensured toast notifications render above popups and remain clickable by adjusting z-index and pointer events.

### Localization

* Added translations for the new "Open in VRChat" button in both English and Japanese locales. [[1]](diffhunk://#diff-015ce0fec25af6404615a6dcc2bcba0ed110cfaf51a3ef7148142c0e579c5fbcR102) [[2]](diffhunk://#diff-0da4236a295442542ff062bc390a1f7b105247f6f2113035118cea63d1e89e44R101)


Closes: #199 